### PR TITLE
adjust for apps/v1 including required selectors on Deployments

### DIFF
--- a/chart-source/azure-vote/templates/deployments.yaml
+++ b/chart-source/azure-vote/templates/deployments.yaml
@@ -1,9 +1,12 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote-back-{{.Release.Name}}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vote-back-{{.Release.Name}}
   template:
     metadata:
       labels:
@@ -16,17 +19,20 @@ spec:
         - containerPort: 6379
           name: redis
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vote-front-{{.Release.Name}}
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: vote-front-{{.Release.Name}}
   strategy:
     rollingUpdate:
       maxSurge: 1
       maxUnavailable: 1
-  minReadySeconds: 5 
+  minReadySeconds: 5
   template:
     metadata:
       labels:


### PR DESCRIPTION
Adjust azure-vote Deployments to align with requirements from move of Deployments to API apps/v1.